### PR TITLE
fix: 低代码引擎升级导致的容器组件内小剪刀无法使用

### DIFF
--- a/lowcode/common/divider.tsx
+++ b/lowcode/common/divider.tsx
@@ -97,10 +97,10 @@ export const Divider = (props: IDividerProps) => {
   }, []);
 
   useEffect(() => {
-    const { selection } = engine.current;
-    if (!selection) return;
+    const { project } = engine.current;
+    if (!project) return;
 
-    selection.onSelectionChange(onSelectionChange);
+    project.currentDocument.onChangeSelection(onSelectionChange);
   }, []);
 
   /*
@@ -282,8 +282,8 @@ const getSplitDimension = (componentName: string) => {
   return dimension;
 };
 
-const getSelectedNode = ({ selection, project }) => {
-  const selectedId = selection.selected[0];
+const getSelectedNode = ({ project }) => {
+  const selectedId = project.currentDocument?.selection.selected[0];
   return selectedId ? project.currentDocument.nodesMap.get(selectedId) : null;
 };
 


### PR DESCRIPTION
<img width="914" alt="image" src="https://user-images.githubusercontent.com/92377270/198840633-5c78c240-117b-49d6-9c6d-1a7ed92255f4.png">
低代码开源引擎升级后，一些相关调用变更了位置，导致小剪刀无法展示。