### PR TITLE
fix: divider disappear

### DIFF
--- a/lowcode/view.tsx
+++ b/lowcode/view.tsx
@@ -104,10 +104,11 @@ const PageView = (props: {
   const hasSection = Array.isArray(_leaf?.schema.children) && _leaf?.schema.children?.length;
 
   useEffect(() => {
+    // 加载切割的交互能力
+    initSingletonDivider();
+
     if (!pageLoaded) {
       registHotKeys();
-      // 加载切割的交互能力
-      initSingletonDivider();
 
       // 增加快捷选择父节点的按钮
       window.parent?.AliLowCodeEngine?.material?.addBuiltinComponentAction({


### PR DESCRIPTION
在编辑的时候，会出现剪刀消失的情况。
![image](https://user-images.githubusercontent.com/17904619/225867558-e1e5d40c-d1ed-41be-ae30-91ca0abe1baa.png)

重现方法：
1. 点击打开左边数据源
2. 编辑源码，保存
3. 重置页面，重新拉一个布局组件

原因：
以上操作会导致 Divider 渲染挂载到页面中的 dom 界面被刷掉。

![image](https://user-images.githubusercontent.com/17904619/225868720-3e616a9f-e34f-458e-90ee-1e580d8c9351.png)
![image](https://user-images.githubusercontent.com/17904619/225868778-c38addc5-085a-4335-a6ca-f4d17c7d5aba.png)


解决方式：
将 `initSingletonDivider` 函数提前，放到 `pageLoaded` 变量判断外。
这样每次 `<PageView />` 重新加载，会进入 `initSingletonDivider` 重新初始化 divider
`initSingletonDivider` 函数中会判断是否渲染过 divider，如果渲染过则不会重复渲染。性能影响应该不大。

